### PR TITLE
# use consistent debug.

### DIFF
--- a/workbench/classes/datatypes/bmp/bmp.conf
+++ b/workbench/classes/datatypes/bmp/bmp.conf
@@ -1,6 +1,6 @@
 ##begin config
 basename BMP
-version 41.7
+version 41.8
 superclass PICTUREDTCLASS
 ##end config
 ##begin cdef


### PR DESCRIPTION
# correct the use of alignwidth/bytes for > 8bit depths (meanings where reversed!)
# handle padding bytes correctly for 16/24bit images.
# tabs -> spaces.